### PR TITLE
In the calculation of efficiencies, the "Integral()" method of the 2D…

### DIFF
--- a/AnaCodes/DrawHVDependencePlots.cc
+++ b/AnaCodes/DrawHVDependencePlots.cc
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
         TFile *file_in = new TFile(Form("AnaClustering_%d_Thr_%1.1f_MinHits_%d.root", run, threshold, MinHits));
 
         TH2D *h_n_uRwell_V_vs_U_MultiHitCl = (TH2D*) file_in->Get("h_n_uRwell_V_vs_U_MultiHitCl");
-        double All_GoodEventts = h_n_uRwell_V_vs_U_MultiHitCl->Integral();
+        double All_GoodEventts = h_n_uRwell_V_vs_U_MultiHitCl->Integral( 0, h_n_uRwell_V_vs_U_MultiHitCl->GetNbinsX() + 1, 0, h_n_uRwell_V_vs_U_MultiHitCl->GetNbinsY() + 1 );
 
         uRwellTools::CalcEfficiencies(h_n_uRwell_V_vs_U_MultiHitCl, eff);
 

--- a/AnaCodes/DrawPlotsWithClustering.cc
+++ b/AnaCodes/DrawPlotsWithClustering.cc
@@ -238,10 +238,10 @@ int main(int argc, char **argv) {
     int binx2 = h_n_uRwell_V_vs_U_MultiHitCl->GetNbinsX() + 1;
     int biny1 = h_n_uRwell_V_vs_U_MultiHitCl->GetYaxis()->FindBin(1);
     int biny2 = h_n_uRwell_V_vs_U_MultiHitCl->GetNbinsY() + 1;
-    double counts_integral = h_n_uRwell_V_vs_U_MultiHitCl->Integral();
+    double counts_integral = h_n_uRwell_V_vs_U_MultiHitCl->Integral(0, binx2, 0, biny2);
     int counts_has_U_Cluster = h_n_uRwell_V_vs_U_MultiHitCl->Integral(binx1, binx2, 1, biny2);
     int counts_has_V_Cluster = h_n_uRwell_V_vs_U_MultiHitCl->Integral(1, binx2, biny1, biny2);
-    int counts_has_AnyCluster = h_n_uRwell_V_vs_U_MultiHitCl->Integral() - h_n_uRwell_V_vs_U_MultiHitCl->GetBinContent(1, 1);
+    int counts_has_AnyCluster = counts_integral - h_n_uRwell_V_vs_U_MultiHitCl->GetBinContent(1, 1);
     int counts_has_U_AND_V_Cluster = h_n_uRwell_V_vs_U_MultiHitCl->Integral(binx1, binx2, biny1, biny2);
     h_n_uRwell_V_vs_U_MultiHitCl->SetAxisRange(0, 10., "Y");
     h_n_uRwell_V_vs_U_MultiHitCl->SetAxisRange(0, 10., "X");

--- a/src/uRwellTools.cc
+++ b/src/uRwellTools.cc
@@ -67,10 +67,10 @@ void uRwellTools::CalcEfficiencies(TH2* h_in, uRwellTools::uRwellEff &eff) {
     int binx2 = h_in->GetNbinsX() + 1;
     int biny1 = h_in->GetYaxis()->FindBin(1);
     int biny2 = h_in->GetNbinsY() + 1;
-    double counts_integral = h_in->Integral();
+    double counts_integral = h_in->Integral(0, binx2, 0, biny2);
     double counts_has_U_Cluster = h_in->Integral(binx1, binx2, 1, biny2);
     double counts_has_V_Cluster = h_in->Integral(1, binx2, biny1, biny2);
-    double counts_has_AnyCluster = h_in->Integral() - h_in->GetBinContent(1, 1);
+    double counts_has_AnyCluster = counts_integral - h_in->GetBinContent(1, 1);
     double counts_has_U_AND_V_Cluster = h_in->Integral(binx1, binx2, biny1, biny2);
 
     eff.eff_U = 100. * counts_has_U_Cluster / counts_integral;


### PR DESCRIPTION
… histogram was called, which actually didn't accound for overflow and underflow entries. Now this is fixed