### PR TITLE
10 add ability to analyze the ldrd gems

### DIFF
--- a/AnaCodes/AnaClustering.cc
+++ b/AnaCodes/AnaClustering.cc
@@ -101,6 +101,7 @@ int main(int argc, char** argv) {
     const int sec_GEM = 8;
     const double GEMHighThreshold = 10.; // 10 Sigma
     const double slot11_StripMin = 577.;
+    const double GEM_strip2Coord = 10. / 256;
 
     hipo::bank buRwellHit(factory.getSchema("uRwell::Hit"));
     hipo::bank bRAWADc(factory.getSchema("RAW::adc"));
@@ -134,11 +135,20 @@ int main(int argc, char** argv) {
     TH2D h_Cross_YXc1("h_Cross_YXc1", "", 1000, -900., 900., 200, -500., 500.);
     TH2D h_Cross_YXc2("h_Cross_YXc2", "", 200, -900., 900., 200, -500., 500.);
     TH2D h_Cross_YXc3("h_Cross_YXc3", "", 1000, -900., 900., 200, -500., 500.);
+
+    TH2D h_Cross_YXc_Max1("h_Cross_YXc_Max1", "", 1000, -900., 900., 200, -500., 500.);
+    TH2D h_Cross_YXc_Max2("h_Cross_YXc_Max2", "", 1000, -900., 900., 200, -500., 500.);
+    TH2D h_Cross_YXc_Max3("h_Cross_YXc_Max3", "", 1000, -900., 900., 200, -500., 500.);
+
+    TH2D h_Cross_YXc_Max_Weighted1("h_Cross_YXc_Max_Weighted1", "", 1000, -900., 900., 200, -500., 500.);
+
     TH2D h_Cross_YXc_Weighted1("h_Cross_YXc_Weighted1", "", 1000, -900., 900., 200, -500., 500.);
     TH2D h_Cross_YXc_Weighted2("h_Cross_YXc_Weighted2", "", 1000, -900., 900., 200, -500., 500.);
     TH2D h_Cross_YXc_Weighted3("h_Cross_YXc_Weighted3", "", 1000, -900., 900., 200, -500., 500.);
 
     TH2D h_GEM_XY1("h_GEM_XY1", "", 129, -0.5, 128.5, 129, -0.5, 128.5);
+    TH2D h_GEM_cl_YXC1("h_GEM_cl_YXC1", "", 100, -0.5, 10.5, 200, -0.5, 10.5);
+    TH2D h_GEM_cl_YXC_MAX1("h_GEM_cl_YXC1_MAX", "", 100, -0.5, 10.5, 200, -0.5, 10.5);
     TH1D h_ADC_GEM_Y1("h_ADC_GEM_Y1", "", 200, 0., 1000.);
     TH1D h_ADC_GEM_X1("h_ADC_GEM_X1", "", 200, 0., 1000.);
 
@@ -218,7 +228,7 @@ int main(int argc, char** argv) {
 
                     if (curHit.layer == layer_X_GEM) {
                         v_X_GEMHits.push_back(curHit);
-                    } else if( curHit.layer == layer_Y_GEM ) {
+                    } else if (curHit.layer == layer_Y_GEM) {
                         v_Y_GEMHits.push_back(curHit);
                     }
                 }
@@ -233,21 +243,27 @@ int main(int argc, char** argv) {
             vector<uRwellCluster> v_Y_GEM_Clusters = uRwellTools::getGlusters(v_Y_GEMHits);
             vector<uRwellCluster> v_X_GEM_Clusters = uRwellTools::getGlusters(v_X_GEMHits);
 
+            uRwellCluster GEM_Max_Y_Cluster = uRwellTools::getMaxAdcCluster( v_Y_GEM_Clusters, 2 );
+            uRwellCluster GEM_Max_X_Cluster = uRwellTools::getMaxAdcCluster( v_X_GEM_Clusters, 2 );
 
-//            for (auto curClust : v_Y_GEM_Clusters) {
-//                cout << "    ******** Cluster ********* " << endl;
-//                cout << "Number of hits      " << curClust.getHits()->size() << endl;
-//                cout << "The AvgStrip is     " << curClust.getAvgStrip() << endl;
-//                cout << "The PeakADC is      " << curClust.getPeakADC() << endl;
-//
-//                vector<uRwellHit> *curHits = curClust.getHits();
-//
-//                for (auto curHit : *curHits) {
-//                    cout << "               **** Hit ***** " << endl;
-//                    cout << "         ADC is            " << curHit.adc << endl;
-//                    cout << "         Strip is          " << curHit.strip << endl;
-//                }
-//            }
+            if( GEM_Max_Y_Cluster.getHits()->size() > 0 && GEM_Max_X_Cluster.getHits()->size() > 0){
+                h_GEM_cl_YXC_MAX1.Fill(GEM_Max_X_Cluster.getAvgStrip()*GEM_strip2Coord, GEM_Max_Y_Cluster.getAvgStrip()*GEM_strip2Coord );
+            }
+            
+            //            for (auto curClust : v_Y_GEM_Clusters) {
+            //                cout << "    ******** Cluster ********* " << endl;
+            //                cout << "Number of hits      " << curClust.getHits()->size() << endl;
+            //                cout << "The AvgStrip is     " << curClust.getAvgStrip() << endl;
+            //                cout << "The PeakADC is      " << curClust.getPeakADC() << endl;
+            //
+            //                vector<uRwellHit> *curHits = curClust.getHits();
+            //
+            //                for (auto curHit : *curHits) {
+            //                    cout << "               **** Hit ***** " << endl;
+            //                    cout << "         ADC is            " << curHit.adc << endl;
+            //                    cout << "         Strip is          " << curHit.strip << endl;
+            //                }
+            //            }
 
             for (auto curHit : v_U_Hits_uRwell) {
 
@@ -267,14 +283,34 @@ int main(int argc, char** argv) {
                 }
             }
 
-            h_n_V_vs_U_Clusters1.Fill(v_U_Clusters.size(), v_V_Clusters.size());
+            int n_U_cl = v_U_Clusters.size();
+            int n_V_cl = v_V_Clusters.size();
+            h_n_V_vs_U_Clusters1.Fill(n_U_cl, n_V_cl);
 
             int n_U_MultiHit_clusters = 0;
             int n_V_MultiHit_clusters = 0;
 
+            uRwellCluster Max_UCluster;
+            uRwellCluster Max_VCluster;
+            uRwellCross curCrs_MaxADC;
+
+            double U_Cl_ADC_Max = 0;
+            double V_Cl_ADC_Max = 0;
+            int max_Ucl_ind = 0;
+            int max_Vcl_ind = 0;
+
             for (int iUcl = 0; iUcl < v_U_Clusters.size(); iUcl++) {
                 int nhits = v_U_Clusters.at(iUcl).getHits()->size();
                 h_n_UclHits1.Fill(nhits);
+
+                if( nhits < MinClSize ){
+                    continue;
+                }
+                
+                if (v_U_Clusters.at(iUcl).getPeakADC() > U_Cl_ADC_Max) {
+                    U_Cl_ADC_Max = v_U_Clusters.at(iUcl).getPeakADC();
+                    max_Ucl_ind = iUcl;
+                }
 
                 if (nhits >= MinClSize) {
                     h_U_Coord_MultrCl1.Fill(v_U_Clusters.at(iUcl).getAvgStrip());
@@ -284,9 +320,20 @@ int main(int argc, char** argv) {
                     h_U_Coord_SingleHitCl1.Fill(v_U_Clusters.at(iUcl).getAvgStrip());
                 }
             }
+
             for (int iVcl = 0; iVcl < v_V_Clusters.size(); iVcl++) {
                 int nhits = v_V_Clusters.at(iVcl).getHits()->size();
                 h_n_VclHits1.Fill(nhits);
+               
+                if( nhits < MinClSize ){
+                    continue;
+                }
+
+                if (v_V_Clusters.at(iVcl).getPeakADC() > V_Cl_ADC_Max) {
+                    V_Cl_ADC_Max = v_V_Clusters.at(iVcl).getPeakADC();
+                    max_Vcl_ind = iVcl;
+                }
+
 
                 if (nhits >= MinClSize) {
                     h_V_Coord_MultrCl1.Fill(v_V_Clusters.at(iVcl).getAvgStrip());
@@ -297,15 +344,30 @@ int main(int argc, char** argv) {
                 }
             }
 
+            if (n_U_MultiHit_clusters >= 1 && n_V_MultiHit_clusters >= 1) {
+                // Done looping over U and V clusters, so let's get the U and V cluster with Maximum energies
+                Max_UCluster = v_U_Clusters.at(max_Ucl_ind);
+                Max_VCluster = v_V_Clusters.at(max_Vcl_ind);
+                // This cross represents the cross with Maximum U and Maximum V cluster
+                curCrs_MaxADC = uRwellCross(Max_UCluster.getAvgStrip(), Max_VCluster.getAvgStrip());
+                h_Cross_YXc_Max1.Fill(curCrs_MaxADC.getX(), curCrs_MaxADC.getY());
+                h_Cross_YXc_Max_Weighted1.Fill( curCrs_MaxADC.getX(), curCrs_MaxADC.getY(), Max_UCluster.getPeakADC() + Max_VCluster.getPeakADC() );
+            }
 
             int n_GEMHits_X = 0;
             int n_GEMHits_Y = 0;
-            
+
             int n_GEM_Y_Cl = v_Y_GEM_Clusters.size();
             int n_GEM_X_Cl = v_X_GEM_Clusters.size();
 
             h_n_GEM_Y_vs_X_Clusters1.Fill(n_GEM_X_Cl, n_GEM_Y_Cl);
-            
+
+            for (auto cur_GEM_X_Cluster : v_X_GEM_Clusters) {
+                for (auto cur_GEM_Y_Cluster : v_Y_GEM_Clusters) {
+                    h_GEM_cl_YXC1.Fill(cur_GEM_X_Cluster.getAvgStrip() * GEM_strip2Coord, cur_GEM_Y_Cluster.getAvgStrip() * GEM_strip2Coord);
+                }
+            }
+
             for (int iGEMHit = 0; iGEMHit < v_GEMHits.size(); iGEMHit++) {
 
                 if (v_GEMHits.at(iGEMHit).strip < 128) {
@@ -393,6 +455,14 @@ int main(int argc, char** argv) {
                 //cout<<"Kuku"<<endl;
                 h_nVcl_vs_Ucoord1.Fill(vAvgStrip, n_U_MultiHit_clusters);
 
+            }
+            if (n_GEM_Y_Cl >= 1 && n_GEM_X_Cl >= 1) {
+                h_Cross_YXc_Max2.Fill(curCrs_MaxADC.getX(), curCrs_MaxADC.getY());
+                
+                if( GEM_Max_Y_Cluster.getHits()->size() > 0 && GEM_Max_X_Cluster.getHits()->size() > 0 
+                        && GEM_Max_Y_Cluster.getAvgStrip()*GEM_strip2Coord > 5 ){
+                    h_Cross_YXc_Max3.Fill(curCrs_MaxADC.getX(), curCrs_MaxADC.getY());
+                }
             }
 
             for (auto cur_Ucl : v_U_Clusters) {

--- a/AnaCodes/AnaClustering.cc
+++ b/AnaCodes/AnaClustering.cc
@@ -95,6 +95,8 @@ int main(int argc, char** argv) {
 
     const int layer_U_uRwell = 1;
     const int layer_V_uRwell = 2;
+    const int layer_X_GEM = 1;
+    const int layer_Y_GEM = 2;
     const int sec_uRwell = 6;
     const int sec_GEM = 8;
     const double GEMHighThreshold = 10.; // 10 Sigma
@@ -213,9 +215,9 @@ int main(int argc, char** argv) {
 
                     v_GEMHits.push_back(curHit);
 
-                    if (curHit.strip < 128) {
+                    if (curHit.layer == layer_X_GEM) {
                         v_X_GEMHits.push_back(curHit);
-                    } else {
+                    } else if( curHit.layer == layer_Y_GEM ) {
                         v_Y_GEMHits.push_back(curHit);
                     }
                 }
@@ -226,6 +228,9 @@ int main(int argc, char** argv) {
 
             vector<uRwellCluster> v_U_Clusters = uRwellTools::getGlusters(v_U_Hits_uRwell);
             vector<uRwellCluster> v_V_Clusters = uRwellTools::getGlusters(v_V_Hits_uRwell);
+
+            vector<uRwellCluster> v_Y_GEM_Clusters = uRwellTools::getGlusters(v_Y_GEMHits);
+            vector<uRwellCluster> v_X_GEM_Clusters = uRwellTools::getGlusters(v_X_GEMHits);
 
 
             //            for (auto curClust : v_U_Clusters) {

--- a/AnaCodes/AnaClustering.cc
+++ b/AnaCodes/AnaClustering.cc
@@ -108,6 +108,7 @@ int main(int argc, char** argv) {
 
     TFile *file_out = new TFile(Form("AnaClustering_%d_Thr_%1.1f_MinHits_%d.root", run, HitThr, MinClSize), "Recreate");
     TH2D h_n_GEM_vs_uRwellHits("h_n_GEM_vs_uRwellHits", "", 31, -0.5, 30, 31, -0.5, 30);
+    TH2D h_n_GEM_Y_vs_X_Clusters1("h_n_GEM_Y_vs_X_Clusters1", "", 11, -0.5, 10.5, 11, -0.5, 10.5);
     TH2D h_n_V_vs_U_hits1("h_n_V_vs_U_hits1", "", 26, -0.5, 25.5, 26, -0.5, 25.5);
 
     TH1D h_U_HitStrip1("h_U_HitStrip1", "", 706, -0.5, 705.5);
@@ -233,20 +234,20 @@ int main(int argc, char** argv) {
             vector<uRwellCluster> v_X_GEM_Clusters = uRwellTools::getGlusters(v_X_GEMHits);
 
 
-            //            for (auto curClust : v_U_Clusters) {
-            //                cout << "    ******** Cluster ********* " << endl;
-            //                cout << "Number of hits      " << curClust.getHits()->size() << endl;
-            //                cout << "The AvgStrip is     " << curClust.getAvgStrip() << endl;
-            //                cout << "The PeakADC is      " << curClust.getPeakADC() << endl;
-            //
-            //                vector<uRwellHit> *curHits = curClust.getHits();
-            //
-            //                for (auto curHit : *curHits) {
-            //                    cout << "               **** Hit ***** " << endl;
-            //                    cout<<"         ADC is            "<<curHit.adc <<endl;
-            //                    cout<<"         Strip is          "<<curHit.strip <<endl;
-            //                }
-            //            }
+//            for (auto curClust : v_Y_GEM_Clusters) {
+//                cout << "    ******** Cluster ********* " << endl;
+//                cout << "Number of hits      " << curClust.getHits()->size() << endl;
+//                cout << "The AvgStrip is     " << curClust.getAvgStrip() << endl;
+//                cout << "The PeakADC is      " << curClust.getPeakADC() << endl;
+//
+//                vector<uRwellHit> *curHits = curClust.getHits();
+//
+//                for (auto curHit : *curHits) {
+//                    cout << "               **** Hit ***** " << endl;
+//                    cout << "         ADC is            " << curHit.adc << endl;
+//                    cout << "         Strip is          " << curHit.strip << endl;
+//                }
+//            }
 
             for (auto curHit : v_U_Hits_uRwell) {
 
@@ -299,7 +300,12 @@ int main(int argc, char** argv) {
 
             int n_GEMHits_X = 0;
             int n_GEMHits_Y = 0;
+            
+            int n_GEM_Y_Cl = v_Y_GEM_Clusters.size();
+            int n_GEM_X_Cl = v_X_GEM_Clusters.size();
 
+            h_n_GEM_Y_vs_X_Clusters1.Fill(n_GEM_X_Cl, n_GEM_Y_Cl);
+            
             for (int iGEMHit = 0; iGEMHit < v_GEMHits.size(); iGEMHit++) {
 
                 if (v_GEMHits.at(iGEMHit).strip < 128) {
@@ -357,7 +363,7 @@ int main(int argc, char** argv) {
 
             h_n_GEM_Y_vs_X_Hits1.Fill(n_GEMHits_X, n_GEMHits_Y);
 
-            if (n_GEMHits_X >= 2 && n_GEMHits_Y >= 2) {
+            if (n_GEM_Y_Cl == 1 && n_GEM_X_Cl == 1) {
                 h_n_uRwell_V_vs_U_MultiHitCl.Fill(n_U_MultiHit_clusters, n_V_MultiHit_clusters);
 
                 for (int iUcl = 0; iUcl < v_U_Clusters.size(); iUcl++) {
@@ -433,7 +439,7 @@ int main(int argc, char** argv) {
                         h_Cross_YXc_Weighted3.Fill(crsX, crsY, cl_ADC_Tot);
                     }
 
-                    if (n_GEMHits_X >= 2 && n_GEMHits_Y >= 2) {
+                    if (n_GEM_Y_Cl == 1 && n_GEM_X_Cl == 1) {
                         h_Cross_YXc2.Fill(crsX, crsY);
                         h_Cross_YXc_Weighted2.Fill(crsX, crsY, cl_ADC_Tot);
                     }

--- a/AnaCodes/CheckDecoding.cc
+++ b/AnaCodes/CheckDecoding.cc
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
 
     TFile *file_out = new TFile(Form("CheckDecoding_%d_%d.root", run, fnum), "Recreate");
     TH2D *h_ADC_chan = new TH2D("h_ADC_chan", "", 1711, -0.5, 1710.5, 400, -400., 400.);
-    TH2D *h_ADC_chan_GEM = new TH2D("h_ADC_chan_GEM", "", 258, -0.5, 257.5, 400, -400., 400.);
+    TH2D *h_ADC_chan_GEM = new TH2D("h_ADC_chan_GEM", "", 1258, -0.5, 1257.5, 400, -400., 400.);
     TH2D *h_ADC_AllChan = new TH2D("h_ADC_AllChan", "", 1711, -0.5, 1710.5, 400, -600., 600.);
     TH2D * h_ADC_Chan_ts_[n_ts];
 
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
                     h_ADC_AllChan->Fill(uniqueChan, ADC);
                     m_ADC_[ts][uniqueChan] = ADC;
                 } else if (sector == 8) {
-                    m_ADC_GEM_[ts][channel] = ADC; //For GEM we will use just the channel
+                    m_ADC_GEM_[ts][uniqueChan] = ADC; // For GEM we will use the uniquechannel as well
                 }
             }
 

--- a/AnaCodes/DrawPlotsWithClustering.cc
+++ b/AnaCodes/DrawPlotsWithClustering.cc
@@ -371,6 +371,14 @@ int main(int argc, char **argv) {
     c2->Print(Form("Figs/Cross_YXc3_Weighted_%d_t%1.1f_m%d.png", run, threshold, MinClSize));
     c2->Print(Form("Figs/Cross_YXc3_Weighted_%d_t%1.1f_m%d.root", run, threshold, MinClSize));
 
+    TH2D *h_AvgADC_Cross_YXc3 = (TH2D*)h_Cross_YXc_Weighted3->Clone("h_AvgADC_Cross_YXc3");
+    h_AvgADC_Cross_YXc3->Divide(h_Cross_YXc3);
+    h_AvgADC_Cross_YXc3->Draw("colz");
+    h_AvgADC_Cross_YXc3->SetMaximum(h_AvgADC_Cross_YXc3->GetMaximum()/2.);
+    c2->Print(Form("Figs/AvgADC_Cross_YXC3_%d_t%1.1f_m%d.pdf", run, threshold, MinClSize));
+    c2->Print(Form("Figs/AvgADC_Cross_YXC3_%d_t%1.1f_m%d.png", run, threshold, MinClSize));
+    c2->Print(Form("Figs/AvgADC_Cross_YXC3_%d_t%1.1f_m%d.root", run, threshold, MinClSize));
+    
     Y_bin2 = h_Cross_YXc_Weighted3->GetYaxis()->FindBin(245);
     Y_bin1 = h_Cross_YXc_Weighted3->GetYaxis()->FindBin(-245);
 

--- a/include/uRwellTools.h
+++ b/include/uRwellTools.h
@@ -148,6 +148,7 @@ namespace uRwellTools {
 
     void DrawGroupStripBiundaries();
 
+    
     class uRwellCluster {
     public:
         uRwellCluster();
@@ -192,6 +193,7 @@ namespace uRwellTools {
 
     class uRwellCross {
     public:
+        uRwellCross();
         uRwellCross(double stripU, double stripV); // stripU and stripV are cluster centers in units of strip numbers, they don't have to be integer
 
         const double getStripU() {
@@ -247,6 +249,8 @@ namespace uRwellTools {
     std::vector<uRwellCluster> getGlusters(std::vector<uRwellHit>);
     double getCrossX(double strip_U, double strip_V); // returns Cross UxV cross X coordinate
     double getCrossY(double strip_U, double strip_V); // returns Cross UxV cross Y coordinate
+    uRwellCluster getMaxAdcCluster(std::vector<uRwellCluster> &, int);
+    
 }
 
 #endif /* URWELLTOOLS_H */

--- a/include/uRwellTools.h
+++ b/include/uRwellTools.h
@@ -78,8 +78,9 @@ namespace uRwellTools {
     const double OneSigma = 0.683;
 
     const int clStripGap = 2; // The Max length of the gap in between strips with a given cluster 
-    int getSlot(int ch);
-    const int nSlot = 12; // The test Prototype has only 12 slots
+    int getURwellSlot(int ch);
+    int getGEMSlot(int ch);
+    const int nSlot = 16; // The test Prototype has only 12 slots
     extern int slot_Offset[nSlot]; // Gives the 1st strip channel (unique channel) for the given slot
 
     const double Y_top_edge = 250;

--- a/src/uRwellTools.cc
+++ b/src/uRwellTools.cc
@@ -8,7 +8,31 @@
 
 using namespace std;
 
-int uRwellTools::getSlot(int ch) {
+int uRwellTools::getGEMSlot(int ch) {
+
+    if (ch < 1 || ch > 1256) {
+        cout << "This should not happen: GEM channel is " << ch << endl;
+        cout << "Exiting" << endl;
+        exit(1);
+    }
+
+    if (ch <= 128) {
+        return 12;
+    } else if (ch >= 129 && ch <= 256) {
+        return 13;
+    } else if (ch >= 1001 && ch <= 1128) {
+        return 14;
+    } else if (ch >= 1129 && ch <= 1256) {
+        return 15;
+    }else {
+        cout << "This should not happen: GEM channel is " << ch << endl;
+        cout << "Exiting" << endl;
+        exit(1);
+    }
+
+}
+
+int uRwellTools::getURwellSlot(int ch) {
 
     if (ch <= 64) {
         return 0;
@@ -40,7 +64,7 @@ int uRwellTools::getSlot(int ch) {
 
 }
 
-int uRwellTools::slot_Offset[uRwellTools::nSlot] = {0, 64, 192, 1448, 320, 1576, 1000, 1064, 1192, 448, 1320, 576};
+int uRwellTools::slot_Offset[uRwellTools::nSlot] = {0, 64, 192, 1448, 320, 1576, 1000, 1064, 1192, 448, 1320, 576, 0, 128, 1000, 1128};
 
 uRwellTools::ADC_Distribution uRwellTools::CalcMPVandMean(TH1D* h_in) {
 
@@ -58,7 +82,7 @@ uRwellTools::ADC_Distribution uRwellTools::CalcMPVandMean(TH1D* h_in) {
     distr.errMean = h_in->GetMeanError();
 
     delete f_Landau;
-    
+
     return distr;
 }
 
@@ -240,8 +264,8 @@ namespace uRwellTools {
             fCrossX = getCrossX(fStripU, fStripV);
             fCrossY = getCrossY(fStripU, fStripV);
 
-            fSlotU = getSlot(int (fStripU));
-            fSlotV = getSlot(int (1000 + fStripV)); // We add 1000, because the the getSlot( ) function as an argument takes global strip number i, 1 to 1704
+            fSlotU = getURwellSlot(int (fStripU));
+            fSlotV = getURwellSlot(int (1000 + fStripV)); // We add 1000, because the the getURwellSlot( ) function as an argument takes global strip number i, 1 to 1704
 
             fgrU = (std::lower_bound(gr_UBounderies.begin(), gr_UBounderies.end(), fStripU) - gr_UBounderies.begin()) - 1;
             fgrV = (std::lower_bound(gr_VBounderies.begin(), gr_VBounderies.end(), fStripV) - gr_VBounderies.begin()) - 1;

--- a/src/uRwellTools.cc
+++ b/src/uRwellTools.cc
@@ -32,7 +32,7 @@ int uRwellTools::getSlot(int ch) {
         return 10;
     } else if (ch >= 1449 && ch <= 1576) {
         return 3;
-    } else if (ch >= 1577 && ch <= 11704) {
+    } else if (ch >= 1577 && ch <= 1704) {
         return 5;
     } else {
         return -1; // Should not happen, non existing slot

--- a/src/uRwellTools.cc
+++ b/src/uRwellTools.cc
@@ -24,7 +24,7 @@ int uRwellTools::getGEMSlot(int ch) {
         return 14;
     } else if (ch >= 1129 && ch <= 1256) {
         return 15;
-    }else {
+    } else {
         cout << "This should not happen: GEM channel is " << ch << endl;
         cout << "Exiting" << endl;
         exit(1);
@@ -208,6 +208,33 @@ void uRwellTools::DrawGroupStripBiundaries() {
 
 namespace uRwellTools {
 
+    uRwellCluster getMaxAdcCluster(std::vector<uRwellCluster> &v_clusters, int MinHits) {
+        int ind_Max = 0;
+        double ADC_Max = 0;
+
+        for (int ind = 0; ind < v_clusters.size(); ind++) {
+
+            if (v_clusters.at(ind).getHits()->size() < MinHits) {
+                continue;
+            }
+
+            if (v_clusters.at(ind).getPeakADC() > ADC_Max) {
+                ADC_Max = v_clusters.at(ind).getPeakADC();
+                ind_Max = ind;
+            }
+        }
+
+        // Check if there is such a cluster, otherwise make a new cluster with 0
+        // energy that easily can be checked 
+        if (ADC_Max > 0) {
+            return v_clusters.at(ind_Max);
+        }else{
+            uRwellCluster tmp;
+            tmp.setEnergy(0);
+            return tmp;
+        }
+    }
+
     uRwellCluster::uRwellCluster() {
         fnStrips = 0;
         fEnergy = 0;
@@ -244,6 +271,9 @@ namespace uRwellTools {
     void uRwellCluster::FinalizeCluster() {
         findPeakEnergy();
         findAvgStrip();
+    }
+
+    uRwellCross::uRwellCross() {
     }
 
     uRwellCross::uRwellCross(double stripU, double stripV) {


### PR DESCRIPTION
Added ability to analyze LDRD GEMs

1) Does clustering for GEMs as well
2) The analysis code is developed as well, so it now from vectors of U and V clusters takes the those with Maximum energies, and makes crosses with only Max energy clusters. Looks like the background significantly reduces. It looks those secondary clusters are formed as a result of cross-talk in the APV25 card.
3) some more tools are added in the UrwellTools class, in particular a method is added that returns the highest energy cluster
from the vector of clusters.